### PR TITLE
cuda-sanitizer-api v12.9.79

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+#   - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,4 @@
+# Please see the note on "arm-variant-feedstock" cbc.yaml file regarding tegra builds
 arm_variant_type: # [aarch64]
   - sbsa          # [aarch64]
-  - tegra         # [aarch64]
-c_stdlib_version:  # [linux]
-  - 2.28           # [linux]
+#  - tegra         # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,12 +25,17 @@ source:
   sha256: b1f366312cb52164dfe7b78463ab085b742f052e74b89e9da08561a8ca8b06e9  # [win]
 
 build:
-  number: 1
+  number: 0
   binary_relocation: false
-  skip: true  # [osx or ppc64le]
+  skip: true  # [osx]
   missing_dso_whitelist:
     - '$RPATH/libInterceptorInjectionTarget.so'  # [linux]
     - '$RPATH/InterceptorInjectionTarget.dll'    # [win]
+  overlinking_ignore_patterns:
+    # Workaround for LIEF's 'not a valid TAG' error
+    - '*TreeLauncher*'        # [linux and aarch64]
+    - '*libsanitizer*.so*'    # [linux and aarch64]
+    - '*compute-sanitizer*'   # [linux and aarch64]
 
 requirements:
   build:
@@ -65,11 +70,13 @@ about:
   license_file: LICENSE
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: Provides a set of APIs to enable third party tools to write GPU sanitizing tools
   description: |
     Provides a set of APIs to enable third-party tools to write GPU sanitizing
     tools, such as memory and race checkers.
   doc_url: https://docs.nvidia.com/compute-sanitizer/SanitizerApiGuide/index.html
+  dev_url: https://docs.nvidia.com/compute-sanitizer/SanitizerApiGuide/index.html
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
cuda-sanitizer-api 12.9.79

**Destination channel:** defaults

### Links

- [PKG-12779](https://anaconda.atlassian.net/browse/PKG-12779) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Added `abs.yaml` for possible use of staging channels in future builds


[PKG-12779]: https://anaconda.atlassian.net/browse/PKG-12779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ